### PR TITLE
Fix #4: initialized sensor with Adafruit_BME280::OPERATING_MODE::Sleep

### DIFF
--- a/examples/catena4630-pms7003-lora/catena4630-pms7003-lora.ino
+++ b/examples/catena4630-pms7003-lora/catena4630-pms7003-lora.ino
@@ -201,7 +201,7 @@ void setup_radio()
 void setup_sensors()
     {
     Wire.begin();
-    gMeasurementLoop.setBme280(gBme280.begin());
+    gMeasurementLoop.setBme280(gBme280.begin(BME280_ADDRESS, Adafruit_BME280::OPERATING_MODE::Sleep));
     }
 
 void setup_pms7003()


### PR DESCRIPTION
Initialized sensor BME280 with Adafruit_BME280::OPERATING_MODE::Sleep, to achieve low power consumption.
https://github.com/mcci-catena/MCCI-Catena-PMS7003/blob/81b1023756591f2f531bcca36797b654b45072ad/examples/catena4630-pms7003-lora/catena4630-pms7003-lora.ino#L204