### PR TITLE
Fix #9: updated .dat files with missing repo and change repo name for I2C_FRAM

### DIFF
--- a/examples/catena4630-revA-pms7003-demo/git-repos.dat
+++ b/examples/catena4630-revA-pms7003-demo/git-repos.dat
@@ -5,12 +5,13 @@
 #
 # The following are needed to support Catena 4630 core.
 #
-github.com	mcci-catena/Catena-Arduino-Platform.git
-github.com	mcci-catena/arduino-lorawan.git
-github.com	mcci-catena/Catena-mcciadk.git
-github.com	mcci-catena/arduino-lmic.git
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
-github.com	mcci-catena/Adafruit_BME280_Library.git
+github.com      mcci-catena/Catena-Arduino-Platform.git
+github.com      mcci-catena/arduino-lorawan.git
+github.com      mcci-catena/Catena-mcciadk.git
+github.com      mcci-catena/arduino-lmic.git
+github.com      mcci-catena/MCCI_FRAM_I2C.git
+github.com      mcci-catena/Adafruit_BME280_Library.git
+github.com      mcci-catena/Adafruit_Sensor.git
 
 # the following are needed for the 4630 function.
 #  none so far

--- a/examples/catena4630-revA-pms7003-lora/git-repos.dat
+++ b/examples/catena4630-revA-pms7003-lora/git-repos.dat
@@ -5,12 +5,13 @@
 #
 # The following are needed to support Catena 4630 core.
 #
-github.com	mcci-catena/Catena-Arduino-Platform.git
-github.com	mcci-catena/arduino-lorawan.git
-github.com	mcci-catena/Catena-mcciadk.git
-github.com	mcci-catena/arduino-lmic.git
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
-github.com	mcci-catena/Adafruit_BME280_Library.git
+github.com      mcci-catena/Catena-Arduino-Platform.git
+github.com      mcci-catena/arduino-lorawan.git
+github.com      mcci-catena/Catena-mcciadk.git
+github.com      mcci-catena/arduino-lmic.git
+github.com      mcci-catena/MCCI_FRAM_I2C.git
+github.com      mcci-catena/Adafruit_BME280_Library.git
+github.com      mcci-catena/Adafruit_Sensor.git
 
 # the following are needed for the 4630 function.
 #  none so far

--- a/examples/catena4630-revB-pms7003-demo/git-repos.dat
+++ b/examples/catena4630-revB-pms7003-demo/git-repos.dat
@@ -5,12 +5,12 @@
 #
 # The following are needed to support Catena 4630 core.
 #
-github.com	mcci-catena/Catena-Arduino-Platform.git
-github.com	mcci-catena/arduino-lorawan.git
-github.com	mcci-catena/Catena-mcciadk.git
-github.com	mcci-catena/arduino-lmic.git
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
-github.com	mcci-catena/MCCI-Catena-SHT3x.git
+github.com      mcci-catena/Catena-Arduino-Platform.git
+github.com      mcci-catena/arduino-lorawan.git
+github.com      mcci-catena/Catena-mcciadk.git
+github.com      mcci-catena/arduino-lmic.git
+github.com      mcci-catena/MCCI_FRAM_I2C.git
+github.com      mcci-catena/MCCI-Catena-SHT3x.git
 
 # the following are needed for the 4630 function.
 #  none so far

--- a/examples/catena4630-revB-pms7003-lora/git-repos.dat
+++ b/examples/catena4630-revB-pms7003-lora/git-repos.dat
@@ -5,12 +5,12 @@
 #
 # The following are needed to support Catena 4630 core.
 #
-github.com	mcci-catena/Catena-Arduino-Platform.git
-github.com	mcci-catena/arduino-lorawan.git
-github.com	mcci-catena/Catena-mcciadk.git
-github.com	mcci-catena/arduino-lmic.git
-github.com	mcci-catena/Adafruit_FRAM_I2C.git
-github.com	mcci-catena/Adafruit_BME280_Library.git
+github.com      mcci-catena/Catena-Arduino-Platform.git
+github.com      mcci-catena/arduino-lorawan.git
+github.com      mcci-catena/Catena-mcciadk.git
+github.com      mcci-catena/arduino-lmic.git
+github.com      mcci-catena/MCCI_FRAM_I2C.git
+github.com      mcci-catena/MCCI-Catena-SHT3x.git
 
 # the following are needed for the 4630 function.
 #  none so far


### PR DESCRIPTION
Added the clone link for missing repo `Adafruit_Sensor` to `.dat` files of RevA examples. Updated name of I2C_FRAM repo to `MCCI_I2C_FRAM` for both RevA and RevB examples.